### PR TITLE
refactor: update timestamp only when no unsuccessful updates

### DIFF
--- a/src/handlers/scheduledEventHandler.ts
+++ b/src/handlers/scheduledEventHandler.ts
@@ -50,17 +50,15 @@ export async function callDiscordNicknameBatchUpdate(env: env) {
 	}
 
 	const data: NicknameUpdateResponseType = await response.json();
-	if (data?.data.totalUsersStatus !== 0 && data?.data.successfulNicknameUpdates === 0) {
-		throw new Error("Error while trying to update users' discord nickname");
+	if (data?.data.unsuccessfulNicknameUpdates === 0) {
+		try {
+			await namespace.put('DISCORD_NICKNAME_UPDATED_TIME', Date.now().toString());
+		} catch (err) {
+			console.error('Error while trying to update the last nickname change timestamp');
+		}
 	}
 
 	console.log(data);
-
-	try {
-		await namespace.put('DISCORD_NICKNAME_UPDATED_TIME', Date.now().toString());
-	} catch (err) {
-		console.error('Error while trying to update the last nickname change timestamp');
-	}
 
 	return data;
 }


### PR DESCRIPTION
Date: 9th December 2023

Developer Name: @bharati-21

----

## Issue Ticket Number:- 
https://github.com/Real-Dev-Squad/website-backend/pull/1755

## Description: 
- The last nickname updated timestamp should only be updated when there are no failures for nickname updates and all the users' discord nickname was updated successfully.

Is Under Feature Flag 
- [ ] Yes
- [x] No

Database changes
- [ ] Yes
- [x] No

Breaking changes (If your feature is breaking/missing something please mention pending tickets)
- [ ] Yes
- [x] No

Is Development Tested?

- [ ] Yes
- [x] No


### Add relevant Screenshot below ( e.g test coverage etc. )

