### PR TITLE
Feat: Add a cron job to hit the filter orphan tasks API every 6hours

### DIFF
--- a/src/handlers/scheduledEventHandler.ts
+++ b/src/handlers/scheduledEventHandler.ts
@@ -153,10 +153,9 @@ export async function filterOrphanTasks(env: env) {
 	let lastOrphanTasksFilteration: string | null = '0';
 	try {
 		lastOrphanTasksFilteration = await namespace.get('ORPHAN_TASKS_UPDATED_TIME');
-		if (lastOrphanTasksFilteration === null) {
-			console.error('Error while fetching KV "ORPHAN_TASKS_UPDATED_TIME" timestamp');
-		}
+
 		if (!lastOrphanTasksFilteration) {
+			console.error('Error while fetching KV "ORPHAN_TASKS_UPDATED_TIME" timestamp');
 			lastOrphanTasksFilteration = '0';
 		}
 	} catch (err) {

--- a/src/handlers/scheduledEventHandler.ts
+++ b/src/handlers/scheduledEventHandler.ts
@@ -155,7 +155,7 @@ export async function filterOrphanTasks(env: env) {
 		lastOrphanTasksFilteration = await namespace.get('ORPHAN_TASKS_UPDATED_TIME');
 
 		if (!lastOrphanTasksFilteration) {
-			console.error('Error while fetching KV "ORPHAN_TASKS_UPDATED_TIME" timestamp');
+			console.log(`Empty KV  ORPHAN_TASKS_UPDATED_TIME: ${lastOrphanTasksFilteration}`);
 			lastOrphanTasksFilteration = '0';
 		}
 	} catch (err) {

--- a/src/handlers/scheduledEventHandler.ts
+++ b/src/handlers/scheduledEventHandler.ts
@@ -150,13 +150,13 @@ export const syncOnboarding31dPlusUsers = async (env: env) => {
 
 export async function filterOrphanTasks(env: env) {
 	const namespace = env[NAMESPACE_NAME] as unknown as KVNamespace;
-	let lastOrphanTasksFilteration: string | null = '0';
+	let lastOrphanTasksFilterationTimestamp: string | null = '0'; // O means it will take the oldest unix timestamp
 	try {
-		lastOrphanTasksFilteration = await namespace.get('ORPHAN_TASKS_UPDATED_TIME');
+		lastOrphanTasksFilterationTimestamp = await namespace.get('ORPHAN_TASKS_UPDATED_TIME');
 
-		if (!lastOrphanTasksFilteration) {
-			console.log(`Empty KV  ORPHAN_TASKS_UPDATED_TIME: ${lastOrphanTasksFilteration}`);
-			lastOrphanTasksFilteration = '0';
+		if (!lastOrphanTasksFilterationTimestamp) {
+			console.log(`Empty KV  ORPHAN_TASKS_UPDATED_TIME: ${lastOrphanTasksFilterationTimestamp}`);
+			lastOrphanTasksFilterationTimestamp = '0'; // O means it will take the oldest unix timestamp
 		}
 	} catch (err) {
 		console.error(err, 'Error while fetching the timestamp of last orphan tasks filteration');
@@ -178,7 +178,7 @@ export async function filterOrphanTasks(env: env) {
 			'Content-Type': 'application/json',
 		},
 		body: JSON.stringify({
-			lastOrphanTasksFilteration,
+			lastOrphanTasksFilterationTimestamp,
 		}),
 	});
 	if (!response.ok) {

--- a/src/handlers/scheduledEventHandler.ts
+++ b/src/handlers/scheduledEventHandler.ts
@@ -4,7 +4,13 @@ import config from '../config/config';
 import { NAMESPACE_NAME } from '../constants';
 import { updateUserRoles } from '../services/discordBotServices';
 import { getMissedUpdatesUsers } from '../services/rdsBackendService';
-import { DiscordUserRole, env, NicknameUpdateResponseType, UserStatusResponse } from '../types/global.types';
+import {
+	DiscordUserRole,
+	env,
+	NicknameUpdateResponseType,
+	OrphanTasksStatusUpdateResponseType,
+	UserStatusResponse,
+} from '../types/global.types';
 import { apiCaller } from '../utils/apiCaller';
 import { chunks } from '../utils/arrayUtils';
 import { generateJwt } from '../utils/generateJwt';
@@ -141,3 +147,52 @@ export const syncIdle7dUsers = async (env: env) => {
 export const syncOnboarding31dPlusUsers = async (env: env) => {
 	return await apiCaller(env, 'discord-actions/group-onboarding-31d-plus', 'PUT');
 };
+
+export async function filterOrphanTasks(env: env) {
+	const namespace = env[NAMESPACE_NAME] as unknown as KVNamespace;
+	let lastOrphanTasksFilteration: string | null = '0';
+	try {
+		lastOrphanTasksFilteration = await namespace.get('ORPHAN_TASKS_UPDATED_TIME');
+		if (lastOrphanTasksFilteration === null) {
+			console.error('Error while fetching KV "ORPHAN_TASKS_UPDATED_TIME" timestamp');
+		}
+		if (!lastOrphanTasksFilteration) {
+			lastOrphanTasksFilteration = '0';
+		}
+	} catch (err) {
+		console.error(err, 'Error while fetching the timestamp of last orphan tasks filteration');
+		throw err;
+	}
+
+	const url = config(env).RDS_BASE_API_URL;
+	let token;
+	try {
+		token = await generateJwt(env);
+	} catch (err) {
+		console.error(`Error while generating JWT token: ${err}`);
+		throw err;
+	}
+	const response = await fetch(`${url}/tasks/orphanTasks`, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${token}`,
+			'Content-Type': 'application/json',
+		},
+		body: JSON.stringify({
+			lastOrphanTasksFilteration,
+		}),
+	});
+	if (!response.ok) {
+		throw new Error('Error while trying to update status of orphan tasks to backlog');
+	}
+
+	const data: OrphanTasksStatusUpdateResponseType = await response.json();
+
+	try {
+		await namespace.put('ORPHAN_TASKS_UPDATED_TIME', Date.now().toString());
+	} catch (err) {
+		console.error('Error while trying to update the last orphan tasks filteration timestamp');
+	}
+
+	return data;
+}

--- a/src/types/global.types.ts
+++ b/src/types/global.types.ts
@@ -19,6 +19,13 @@ export type NicknameUpdateResponseType = {
 		unsuccessfulNicknameUpdates: number;
 	};
 };
+
+export type OrphanTasksStatusUpdateResponseType = {
+	message: string;
+	data: {
+		orphanTasksUpdatedCount: number;
+	};
+};
 export type DiscordUsersResponse = {
 	message: string;
 	data: DiscordUserIdList;

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,6 +1,7 @@
 import {
 	addMissedUpdatesRole,
 	callDiscordNicknameBatchUpdate,
+	filterOrphanTasks,
 	syncExternalAccounts,
 	syncIdle7dUsers,
 	syncIdleUsers,
@@ -20,7 +21,10 @@ export default {
 	async scheduled(req: ScheduledController, env: env, ctx: ExecutionContext) {
 		switch (req.cron) {
 			case EVERY_6_HOURS: {
-				return await callDiscordNicknameBatchUpdate(env);
+				await callDiscordNicknameBatchUpdate(env);
+				await filterOrphanTasks(env);
+				console.log('Worker for filtering the orphan tasks has completed');
+				break;
 			}
 			case EVERY_11_HOURS: {
 				return await addMissedUpdatesRole(env);


### PR DESCRIPTION
<!-- Date Here in dd mmm yyyy-->
Date: 2/04/2024
<!--Developer Name Here-->
Developer Name: @MehulKChaudhari 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- https://github.com/Real-Dev-Squad/todo-action-items/issues/215
- https://github.com/Real-Dev-Squad/website-backend/pull/1996

## Description

This PR add's cron job which run every 6hours and hits orphan tasks API, That API filters all the tasks from users who are not in discord server and the tasks which are not `DONE` are marked as `BACKLOG`

##Warning ⚠️ 

Please merge this PR after https://github.com/Real-Dev-Squad/website-backend/pull/1996

### Documentation Updated?

- [ ] Yes
- [x] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [x] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [x] Yes
- [ ] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [x] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [ ] No

<!--Confirmation of local testing during development-->


