### PR TITLE
fix(missed-updates): pass includeHistoricalOoo flag in cron worker requests

### DIFF
--- a/src/services/rdsBackendService.ts
+++ b/src/services/rdsBackendService.ts
@@ -8,6 +8,7 @@ export const getMissedUpdatesUsers = async (env: env, cursor: string | undefined
 
 		const url = new URL(`${baseUrl}/tasks/users/discord`);
 		url.searchParams.append('q', 'status:missed-updates -days-count:3');
+		url.searchParams.append('includeHistoricalOoo', 'true');
 		if (cursor) {
 			url.searchParams.append('cursor', cursor);
 		}

--- a/src/tests/services/rdsBackendService.test.ts
+++ b/src/tests/services/rdsBackendService.test.ts
@@ -22,6 +22,7 @@ describe('rdsBackendService', () => {
 			const result = await getMissedUpdatesUsers({}, cursor);
 			const url = new URL(`${config({}).RDS_BASE_API_URL}/tasks/users/discord`);
 			url.searchParams.append('q', 'status:missed-updates -days-count:3');
+			url.searchParams.append('includeHistoricalOoo', 'true');
 			expect(fetch).toHaveBeenCalledWith(url, {
 				method: 'GET',
 				headers: {
@@ -40,6 +41,7 @@ describe('rdsBackendService', () => {
 			const result = await getMissedUpdatesUsers({}, 'cursorValue');
 			const url = new URL(`${config({}).RDS_BASE_API_URL}/tasks/users/discord`);
 			url.searchParams.append('q', 'status:missed-updates -days-count:3');
+			url.searchParams.append('includeHistoricalOoo', 'true');
 			url.searchParams.append('cursor', 'cursorValue');
 			expect(fetch).toHaveBeenCalledWith(url, {
 				method: 'GET',


### PR DESCRIPTION

<!-- Date Here in dd mmm yyyy-->
Date: `November 6, 2025`
<!--Developer Name Here-->
Developer Name: @Achintya-Chatterjee 

---

## Issue Ticket Number
<!--Issue ticket this PR closes-->
- Closes https://github.com/Real-Dev-Squad/website-backend/issues/2489
## Description
<!--Description of the changes made in this PR-->
- update `getMissedUpdatesUsers` to append `includeHistoricalOoo=true` when
  calling /tasks/users/discord so the backend can factor in OOO history
- adjust service tests to expect the new query parameter with and without
  cursors.
  
### Documentation Updated?

- [ ] Yes
- [ ] No

<!--Additional notes about documentation update if applicable-->

### Under Feature Flag

- [ ] Yes
- [ ] No

<!--Indicate if changes are under a feature flag-->

### Database Changes

- [ ] Yes
- [ ] No

<!--Notes on any database changes-->

### Breaking Changes

- [ ] Yes
- [ ] No

<!--Notes on breaking changes or related issue tickets if applicable-->

### Development Tested?

- [ ] Yes
- [ ] No

<!--Confirmation of local testing during development-->

## Screenshots
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach or link to relevant screenshots or visual aids-->

## Test Coverage
<details>
<summary>Screenshot 1</summary>

<!-- Attach your screenshots here👇-->

</details>

<!--Attach Details on test coverage and outcomes-->

## Additional Notes
This keeps the worker in sync with the backend changes that exclude
users still on or just returning from OOO from the negligent role flow.
<!--Any additional notes, considerations or explanations for reviewers-->
